### PR TITLE
Inhibit mouse until all data is read

### DIFF
--- a/cores/ps2/rtl/ps2.v
+++ b/cores/ps2/rtl/ps2.v
@@ -303,6 +303,7 @@ module ps2 (
 
     .readdata (MSE_dat_o), // data read
     .irq      (MSE_RDY),   // signal data has arrived and is ready to be read
+    .inhibit  (MSE_INT),
 
     .error_sending_command (MSE_TOER),  // Time out error
     .buffer_overrun_error  (MSE_OVER)    // Buffer over run error

--- a/cores/ps2/rtl/ps2_mouse.v
+++ b/cores/ps2/rtl/ps2_mouse.v
@@ -152,6 +152,7 @@ module ps2_mouse (
     .reset                         (reset),
     .the_command                   (the_command),
     .send_command                  (send_command),
+    .inhibit                       (inhibit),
     .ps2_clk_posedge               (ps2_clk_posedge),
     .ps2_clk_negedge               (ps2_clk_negedge),
     .ps2_clk                       (ps2_clk),        // Bidirectionals

--- a/cores/ps2/rtl/ps2_mouse.v
+++ b/cores/ps2/rtl/ps2_mouse.v
@@ -22,6 +22,7 @@ module ps2_mouse (
     input reset,              // Reset Input
     inout ps2_clk,            // PS2 Clock, Bidirectional
     inout ps2_dat,            // PS2 Data, Bidirectional
+    input inhibit,
 
     input  [7:0] the_command,        // Command to send to mouse
     input        send_command,       // Signal to send

--- a/cores/ps2/rtl/ps2_mouse_cmdout.v
+++ b/cores/ps2/rtl/ps2_mouse_cmdout.v
@@ -24,6 +24,7 @@ module ps2_mouse_cmdout (
     input       send_command,
     input       ps2_clk_posedge,
     input       ps2_clk_negedge,
+    input       inhibit,
     inout       ps2_clk,
     inout       ps2_dat,
     output reg  command_was_sent,
@@ -219,7 +220,7 @@ module ps2_mouse_cmdout (
   // --------------------------------------------------------------------
   // Combinational logic
   // --------------------------------------------------------------------
-  assign ps2_clk    = (s_ps2_transmitter == PS2_STATE_1_INITIATE_COMMUNICATION) ? 1'b0 : 1'bz;
+  assign ps2_clk    = (s_ps2_transmitter == PS2_STATE_1_INITIATE_COMMUNICATION || inhibit) ? 1'b0 : 1'bz;
 
   assign ps2_dat    = (s_ps2_transmitter == PS2_STATE_3_TRANSMIT_DATA) ? ps2_command[cur_bit] :
                   (s_ps2_transmitter == PS2_STATE_2_WAIT_FOR_CLOCK) ? 1'b0 :

--- a/cores/ps2/rtl/ps2_mouse_nofifo.v
+++ b/cores/ps2/rtl/ps2_mouse_nofifo.v
@@ -23,7 +23,7 @@ module ps2_mouse_nofifo (
 
     input  [7:0] writedata,   // data to send
     input        write,       // signal to send it
-
+    input        inhibit,
     output [7:0] readdata,    // data read
     output       irq,         // signal data has arrived
 
@@ -51,6 +51,7 @@ module ps2_mouse_nofifo (
 
     .received_data    (readdata),
     .received_data_en (irq),
+    .inhibit          (inhibit),
 
     .command_was_sent              (command_was_sent),
     .error_communication_timed_out (error_sending_command),


### PR DESCRIPTION
While mouse data isn't read from the ps2 controller the mouse should be inhibited. Fixes mouse behavious in Lemmings and Dune2 when moving the mouse at moments it's not expected.